### PR TITLE
fix publiccode.yml validation errors

### DIFF
--- a/.github/workflows/publiccodeyml-check.yml
+++ b/.github/workflows/publiccodeyml-check.yml
@@ -1,0 +1,27 @@
+name: Validate publiccode.yml
+
+on:
+  push:
+    paths:
+      - "publiccode.yml"
+      - ".github/workflows/publiccode.yml"
+  pull_request:
+    paths:
+      - "publiccode.yml"
+      - ".github/workflows/publiccode.yml"
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: publiccode.yml validation
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - uses: italia/publiccode-parser-action@21086c73ec0563e14c6748787efa1b34b025ad8c # v1
+        with:
+          publiccode: "publiccode.yml"
+          no-network: true

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,4 +1,4 @@
-publiccodeYmlVersion: '0.2'
+publiccodeYmlVersion: '0'
 
 releaseDate: '2018-12-17'
 name: Agave CMS
@@ -23,25 +23,19 @@ maintenance:
 
 legal:
   license: 'AGPL-3.0'
-  repoOwner: Team per la Trasformazione Digitale - Presidenza del Consiglio dei Ministri
 
 localisation:
-  localisationReady: yes
+  localisationReady: true
   availableLanguages:
     - it
     - en
 
-it:
-  countryExtensionVersion: '0.2'
-  conforme:
-    misureMinimeSicurezza: yes
-    gdpr: yes
-  riuso:
-    codiceIPA: PCM
+organisation:
+  uri: 'urn:x-italian-pa:PCM'
+
 
 description:
   it:
-    genericName: Content Management System
     features:
       - editor HTML 
       - gestione SEO


### PR DESCRIPTION
`localisationReady` was the YAML 1.1 `yes` which now parses as a string, plus a few deprecated fields.

Also added a GitHub Actions workflow so these get caught automatically on future PRs.